### PR TITLE
Adds unique id logic to TOC heading items

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,18 +15,24 @@ async function Home() {
 
   return (
     <Page breadcrumbs={breadcrumbs} aside={asideMarkup}>
-      <Text variant="headingLg" className="mb-4">
+      <Text variant="headingLg" className="mb-2">
         Intro
       </Text>
-      <Text variant="bodyMd" className="mb-4">
+      <Text variant="bodyMd" className="mb-6">
         Welcome to my corner of the internet.
       </Text>
 
-      <h2>Test Heading 2</h2>
-      <p>Test paragraph</p>
+      <Text variant="headingMd" className="mb-2">
+        Test Heading 2
+      </Text>
+      <Text variant="bodyMd" className="mb-6">
+        Test paragraph
+      </Text>
 
-      <h3>Test Heading 3</h3>
-      <p>Test paragraph</p>
+      <Text variant="headingSm" className="mb-2">
+        Test Heading 3
+      </Text>
+      <Text variant="bodyMd">Test paragraph</Text>
     </Page>
   );
 }

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -10,10 +10,9 @@ export function Sidebar() {
   const { isSidebarOpen } = useContext(SidebarContext);
 
   return (
-    // <nav className="sticky top-10 hidden h-min w-72 md:flex md:shrink-0 md:flex-col md:gap-14">
     <nav
       className={cn(
-        "hidden h-min w-72 overflow-x-hidden md:shrink-0 md:flex-col md:gap-14",
+        "hidden h-min w-56 overflow-x-hidden md:shrink-0 md:flex-col md:gap-14",
         { "md:flex": isSidebarOpen }
       )}
     >

--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import React, { useState } from "react";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
 import { useHeadingsData } from "@/hooks/useHeadingsData";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
-import { cn } from "@/utilities/mergeClassNames";
+import { TableOfContentsItem } from "@/components/TableOfContentsItem";
 
 export interface NestedHeading {
   id: string;
@@ -22,47 +20,20 @@ export type HeadingsProps = {
 };
 
 function Headings({ headings, activeId }: HeadingsProps) {
-  const pathName = usePathname();
-
   return (
     <ul className="relative flex flex-col gap-1 before:absolute before:top-0 before:h-full before:border-l before:border-solid before:border-stone-200">
       {headings.map((heading) => (
         <li key={heading.id}>
-          <Link
-            href={`${pathName}#${heading.id}`}
-            className={cn(
-              "block py-1 pl-3 text-[13px] leading-4 text-stone-500",
-              { "font-medium text-stone-800": heading.id === activeId }
-            )}
-            onClick={(e) => {
-              e.preventDefault();
-
-              document
-                ?.querySelector(`#${heading.id}`)
-                ?.scrollIntoView({ behavior: "smooth" });
-            }}
-          >
+          <TableOfContentsItem id={heading.id} activeId={activeId}>
             {heading.title}
-          </Link>
+          </TableOfContentsItem>
           {heading.items.length > 0 && (
             <ul className="relative flex flex-col gap-1 pl-4 before:absolute before:top-0 before:h-full before:border-l before:border-solid before:border-stone-200">
               {heading.items.map((child) => (
                 <li key={child.id}>
-                  <Link
-                    href={`#${child.id}`}
-                    className={cn(
-                      "block py-1 pl-3 text-[13px] leading-4 text-stone-500",
-                      { "font-medium text-stone-800": child.id === activeId }
-                    )}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      document?.querySelector(`#${child.id}`)?.scrollIntoView({
-                        behavior: "smooth",
-                      });
-                    }}
-                  >
+                  <TableOfContentsItem id={child.id} activeId={activeId}>
                     {child.title}
-                  </Link>
+                  </TableOfContentsItem>
                 </li>
               ))}
             </ul>

--- a/components/TableOfContentsItem.tsx
+++ b/components/TableOfContentsItem.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { cn } from "@/utilities/mergeClassNames";
+
+type Props = {
+  id: string;
+  activeId: string;
+  children: React.ReactNode;
+};
+
+export function TableOfContentsItem({ id, activeId, children }: Props) {
+  const pathName = usePathname();
+  const router = useRouter();
+
+  const pathWithId = `${pathName}#${id}`;
+
+  return (
+    <Link
+      href={pathWithId}
+      className={cn("block py-1 pl-3 text-[13px] leading-4 text-stone-500", {
+        "font-medium text-stone-800": id === activeId,
+      })}
+      onClick={(e) => {
+        e.preventDefault();
+
+        router.push(pathWithId);
+
+        document
+          ?.querySelector(`#${id}`)
+          ?.scrollIntoView({ behavior: "smooth" });
+      }}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/shared/components/Text.tsx
+++ b/shared/components/Text.tsx
@@ -11,27 +11,43 @@ export function Text({ children, variant, className }: Props) {
   function getElementType() {
     switch (variant) {
       case "headingSm":
-        return "h3";
+        return { elementType: "h3", isHeader: true };
       case "headingMd":
-        return "h2";
+        return { elementType: "h2", isHeader: true };
       case "headingLg":
-        return "h1";
+        return { elementType: "h1", isHeader: true };
       default:
-        return "p";
+        return { elementType: "p", isHeader: false };
     }
   }
 
+  function generateIdFromText(text: React.ReactNode): string {
+    if (typeof text === "string") {
+      return text
+        .toLowerCase()
+        .replace(/\s+/g, "-")
+        .replace(/[^\w-]+/g, "");
+    }
+    return "";
+  }
+
+  const { elementType, isHeader } = getElementType();
+  const id = isHeader ? generateIdFromText(children) : undefined;
+
   const variantClasses = {
-    bodySm: "text-base",
-    bodyMd: "text-base",
-    headingSm: "text-base font-medium",
-    headingMd: "text-base font-medium",
-    headingLg: "text-base font-medium",
+    bodySm: "text-sm",
+    bodyMd: "text-sm",
+    headingSm: "text-sm font-medium",
+    headingMd: "text-sm font-medium",
+    headingLg: "text-sm font-medium",
   };
 
   return createElement(
-    getElementType(),
-    { className: cn(variantClasses[variant], className) },
+    elementType,
+    {
+      className: cn(variantClasses[variant], className),
+      ...(isHeader && { id }),
+    },
     children
   );
 }


### PR DESCRIPTION
Closes: https://github.com/juwanpetty/juwanpetty.com/issues/46

Updates the `<Text />` component to generate an ID when a heading variant is passed. TOC uses the ID to identify each header item

![CleanShot 2024-06-02 at 11 57 25@2x](https://github.com/juwanpetty/juwanpetty.com/assets/10606336/4d934b58-0916-4e84-8cd1-d22299992c3f)



https://github.com/juwanpetty/juwanpetty.com/assets/10606336/bcdd7e45-aca6-4c1c-b148-7831ff6b64a9

